### PR TITLE
fix(hlog/sentry): capture original error to preserve stack trace

### DIFF
--- a/hlog/logdriver/sentry.go
+++ b/hlog/logdriver/sentry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kamva/gutil"
 	"github.com/kamva/hexa"
 	"github.com/kamva/hexa/hlog"
+	"go.uber.org/zap/zapcore"
 )
 
 type SentryOptions struct {
@@ -108,7 +109,28 @@ func (l *sentryLogger) Warn(msg string, args ...hlog.Field) { //nolint:revive
 }
 
 func (l *sentryLogger) Error(msg string, args ...hlog.Field) {
-	l.With(args...).(*sentryLogger).hub.CaptureException(errors.New(msg))
+	sl := l.With(args...).(*sentryLogger)
+	if err := extractError(args); err != nil {
+		sl.hub.CaptureException(err)
+		return
+	}
+	sl.hub.CaptureException(errors.New(msg))
+}
+
+// extractError scans the log fields for an error value (e.g. provided via
+// hlog.Err / hlog.NamedErr) and returns the first one found. Capturing the
+// original error preserves its wrap chain and stack trace in Sentry instead
+// of grouping every issue to the driver's own call site.
+func extractError(args []hlog.Field) error {
+	for _, f := range args {
+		if f.Type != zapcore.ErrorType {
+			continue
+		}
+		if err, ok := f.Interface.(error); ok && err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // NewSentryDriver return new instance of hexa logger with sentry driver.

--- a/hlog/logdriver/sentry.go
+++ b/hlog/logdriver/sentry.go
@@ -111,7 +111,10 @@ func (l *sentryLogger) Warn(msg string, args ...hlog.Field) { //nolint:revive
 func (l *sentryLogger) Error(msg string, args ...hlog.Field) {
 	sl := l.With(args...).(*sentryLogger)
 	if err := extractError(args); err != nil {
-		sl.hub.CaptureException(err)
+		// Wrap with msg so the operation-level context is kept as the
+		// exception text while the original error's wrap chain and stack
+		// trace are preserved for Sentry's grouping.
+		sl.hub.CaptureException(fmt.Errorf("%s: %w", msg, err))
 		return
 	}
 	sl.hub.CaptureException(errors.New(msg))

--- a/hlog/logdriver/sentry_test.go
+++ b/hlog/logdriver/sentry_test.go
@@ -1,0 +1,52 @@
+package logdriver
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kamva/hexa/hlog"
+)
+
+func TestExtractError(t *testing.T) {
+	wrapped := errors.New("db connection refused")
+
+	tests := []struct {
+		name string
+		args []hlog.Field
+		want error
+	}{
+		{
+			name: "no fields",
+			args: nil,
+			want: nil,
+		},
+		{
+			name: "no error field",
+			args: []hlog.Field{hlog.String("user_id", "42"), hlog.Int("count", 3)},
+			want: nil,
+		},
+		{
+			name: "error field via hlog.Err",
+			args: []hlog.Field{hlog.Any("user_id", "42"), hlog.Err(wrapped)},
+			want: wrapped,
+		},
+		{
+			name: "error field via hlog.NamedErr",
+			args: []hlog.Field{hlog.NamedErr("cause", wrapped)},
+			want: wrapped,
+		},
+		{
+			name: "nil error field",
+			args: []hlog.Field{hlog.Err(nil)},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractError(tt.args); got != tt.want {
+				t.Fatalf("extractError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `sentryLogger.Error` built a fresh `errors.New(msg)` and captured that, so every Sentry issue grouped to the driver's own call site (`logdriver/sentry.go`), lost the caller's wrapped error chain, and fell back to message-string fingerprinting.
- Now extracts the real `error` from the log fields (`hlog.Err` / `hlog.NamedErr`, which carry a `zapcore.ErrorType` field) and captures it, so sentry-go's stacktrace integration walks the actual error chain. Falls back to the message-derived error only when no error field is present.
- Added `extractError` helper plus unit tests.

## Test plan
- [x] `go build ./hlog/...`
- [x] `go vet ./hlog/...`
- [x] `go test ./hlog/logdriver/ -run TestExtractError` (covers no fields, no error field, `hlog.Err`, `hlog.NamedErr`, nil error)

Note: pre-existing build failures in the unrelated `hurl` package are untouched by this change.

https://claude.ai/code/session_0186XxzUXA9dMqjx8LSxxV6K

---
_Generated by [Claude Code](https://claude.ai/code/session_0186XxzUXA9dMqjx8LSxxV6K)_