### PR TITLE
fix(hurl): repair broken build and avoid nil-base panic

### DIFF
--- a/hurl/client.go
+++ b/hurl/client.go
@@ -37,13 +37,12 @@ type Client struct {
 }
 
 func NewClient(base string, logMode uint) (*Client, error) {
-	var u *URL
-	var err error
-	if base != "" {
-		u, err = NewURL(base)
-		if err != nil {
-			return nil, tracer.Trace(err)
-		}
+	// NewURL returns a non-nil *URL even for an empty base, so methods on
+	// c.base never dereference a nil receiver. A relative request path with
+	// no base then returns a clear error instead of panicking.
+	u, err := NewURL(base)
+	if err != nil {
+		return nil, tracer.Trace(err)
 	}
 
 	return NewClientWithOptions(&http.Client{}, u, logMode), nil

--- a/hurl/error.go
+++ b/hurl/error.go
@@ -2,6 +2,7 @@ package hurl
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -9,7 +10,7 @@ import (
 type HTTPErr struct {
 	Code   int
 	Status string
-	Body string
+	Body   string
 }
 
 func (err HTTPErr) Error() string {
@@ -17,12 +18,13 @@ func (err HTTPErr) Error() string {
 }
 
 // ResponseErr returns http error if the response is not successful.
-func responseErr(r *http.Response) error {
+func ResponseErr(r *http.Response) error {
 	if r.StatusCode <= 300 {
 		return nil
 	}
 
 	body, _ := io.ReadAll(r.Body)
+	_ = r.Body.Close()
 
-	return HttpErr{r.StatusCode, r.Status, string(body)}
+	return HTTPErr{r.StatusCode, r.Status, string(body)}
 }


### PR DESCRIPTION
## Summary

The `hurl` package currently **does not compile**, which breaks `go build ./...` for the whole module. This was introduced by `74c267d "Add body in hurl errors"`.

- `error.go` used `io.ReadAll` without importing `io`, referenced an undefined `HttpErr` (the type is `HTTPErr`), and named the function `responseErr` while `util.go` calls the exported `ResponseErr`. Fixed all three and now close the response body after reading it for the error message (it was leaked).
- `NewClient("", …)` left `c.base` a nil `*URL`; a relative request path then dereferenced a nil receiver in `getFromBase` and panicked before the existing "provide base url" guard could run. `NewClient` now always builds the URL via `NewURL`, which returns a non-nil value for an empty base.

Commits are split so the critical build fix can be reviewed independently of the nil-base hardening.

## Test plan
- [x] `go build ./hurl/...`
- [x] `go test ./hurl/...`
- [x] `gofmt -l hurl/` clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_