### PR TITLE
fix(sr): correct multi-registry off-by-one and Health clobbering

### DIFF
--- a/sr/multi_registry.go
+++ b/sr/multi_registry.go
@@ -11,7 +11,7 @@ type multiSearchRegistry struct {
 
 func (m *multiSearchRegistry) Descriptors() []*hexa.Descriptor {
 	l := make([]*hexa.Descriptor, 0)
-	for i := len(m.search) - 1; i > 0; i-- { // get descriptor list from registries in revert order.
+	for i := len(m.search) - 1; i >= 0; i-- { // get descriptor list from registries in revert order.
 		l = append(l, m.search[i].Descriptors()...)
 	}
 

--- a/sr/registry.go
+++ b/sr/registry.go
@@ -59,10 +59,6 @@ func (r *serviceRegistry) RegisterByDescriptor(d *hexa.Descriptor) {
 		}
 	}
 
-	if h, ok := d.Instance.(hexa.Health); ok {
-		d.Health = h
-	}
-
 	if d.Priority == 0 { // Priority zero means set to the next priority value.
 		d.Priority = len(r.l) + 1 // Add +1 to begin from 1 instead of zero.
 	}


### PR DESCRIPTION
## Summary

Two distinct correctness bugs in the service registry (`sr`):

- **`multiSearchRegistry.Descriptors()` dropped the first registry.** The reverse loop used `i > 0`, so index `0` of the search list was never appended. Changed to `i >= 0`.
- **`RegisterByDescriptor` clobbered an explicitly set `d.Health`.** The instance-derived Health was correctly guarded by `if d.Health == nil`, but a second *unconditional* block immediately overwrote it again, defeating the guard whenever the instance also implemented `hexa.Health`. Removed the redundant block.

Each fix is its own commit.

## Test plan
- [x] `go build ./sr/...`
- [x] `gofmt -l sr/` clean

(No existing tests in this package; behavior verified by inspection.)

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_