### PR TITLE
fix(hlog): correct global Message wiring and FieldToKeyVal decoding

### DIFF
--- a/hlog/global.go
+++ b/hlog/global.go
@@ -12,7 +12,7 @@ func SetGlobalLogger(l Logger) {
 	With = global.With
 	Debug = global.Debug
 	Info = global.Info
-	Message = global.Info
+	Message = global.Message
 	Warn = global.Warn
 	Error = global.Error
 }

--- a/hlog/util.go
+++ b/hlog/util.go
@@ -5,27 +5,13 @@ import (
 )
 
 func FieldToKeyVal(f Field) (key string, val any) {
-	if f.Interface != nil {
-		return f.Key, f.Interface
-	}
-
-	if f.String != "" || f.Type == zapcore.StringerType {
-		return f.Key, f.String
-	}
-
-	return f.Key, f.Integer
-
-	//switch f.Type {
-	//case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type, zapcore.UintptrType,
-	//	zapcore.Uint64Type, zapcore.Uint32Type, zapcore.Uint16Type, zapcore.Uint8Type, zapcore.DurationType:
-	//	val = f.Integer
-	//case zapcore.StringType:
-	//	val = f.String
-	//default:
-	//	val = f.Interface
-	//}
-	//
-	//return f.Key, val
+	// Let zap decode the field into its real Go value. The previous manual
+	// logic returned f.Integer for any non-string/non-interface field, which
+	// is wrong for bool/float/duration/time fields (zap packs those into the
+	// Integer bits), and returned the Stringer object instead of its string.
+	enc := zapcore.NewMapObjectEncoder()
+	f.AddTo(enc)
+	return f.Key, enc.Fields[f.Key]
 }
 
 func fieldsToMap(fields ...Field) map[string]any {

--- a/hlog/util_test.go
+++ b/hlog/util_test.go
@@ -2,6 +2,7 @@ package hlog
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,4 +35,16 @@ func TestFieldToKeyValMap(t *testing.T) {
 	k, v := FieldToKeyVal(f)
 	assert.Equal(t, k, "a")
 	assert.NotNil(t, v)
+}
+
+func TestFieldToKeyValBool(t *testing.T) {
+	k, v := FieldToKeyVal(Bool("a", true))
+	assert.Equal(t, "a", k)
+	assert.Equal(t, true, v) // not int64(1)
+}
+
+func TestFieldToKeyValDuration(t *testing.T) {
+	k, v := FieldToKeyVal(Duration("a", time.Second))
+	assert.Equal(t, "a", k)
+	assert.Equal(t, time.Second, v) // not the raw nanosecond int64
 }


### PR DESCRIPTION
## Summary

Two bugs in `hlog`:

- **`SetGlobalLogger` bound `Message` to `global.Info`** (should be `global.Message`). After any driver was installed, `hlog.Message(...)` lost the driver's Message semantics — notably the Sentry driver's `CaptureMessage` was never called (its `Info` is a no-op). The package-var initializer already used `global.Message`; this aligns `SetGlobalLogger` with it.
- **`FieldToKeyVal` returned raw integer bits for non-string scalar fields.** zap packs `bool`/`float`/`duration`/`time` values into `Field.Integer`, so a `bool` came out as `1`, a `duration` as its raw nanoseconds, etc., and `Stringer` fields were returned as the object instead of the string. These values feed Sentry tags/extras and the printer logger. It now decodes each field with `zapcore`'s map encoder, which yields the proper Go value for every field type.

Added `bool`/`duration` regression tests; existing `FieldToKeyVal` tests still pass.

## Test plan
- [x] `go build ./hlog/...`
- [x] `go test ./hlog/...` (incl. `./hlog/logdriver`)
- [x] new `TestFieldToKeyValBool` / `TestFieldToKeyValDuration` pass
- [x] `gofmt -l hlog/` clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_