### PR TITLE
fix(lg): return repackaged embedded fields from UseEmbeddedFieldsInPackage

### DIFF
--- a/lg/embedded_resolver.go
+++ b/lg/embedded_resolver.go
@@ -200,7 +200,7 @@ func UseEmbeddedFieldsInPackage(from *Package, fields []*EmbeddedField) []*Embed
 		}
 	}
 
-	return fields
+	return l
 }
 
 // UseFieldsInPackage updates fields to be able to use in the another package.


### PR DESCRIPTION
## Summary

`UseEmbeddedFieldsInPackage` built a new slice `l` with package-qualified embedded-field types, then returned the **original** `fields`, silently throwing away the repackaging. Its siblings `UseFieldsInPackage` and `UseMethodsInPackage` correctly return their rebuilt slice. Return `l`.

## Test plan
- [x] `go build ./lg/...`
- [x] `go test ./lg/...`
- [x] `gofmt -l lg/embedded_resolver.go` clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_