### PR TITLE
fix(hexa): base-translator key, userless propagation, and user meta validation

### DIFF
--- a/context.go
+++ b/context.go
@@ -78,7 +78,7 @@ func CtxBaseLogger(ctx context.Context) hlog.Logger {
 // WithBaseTranslator sets the base Translator in the context. when you change the locale,
 // we use the base translator to set the new translator.
 func WithBaseTranslator(ctx context.Context, t Translator) context.Context {
-	return updateTranslator(context.WithValue(ctx, ctxKeyTranslator, t))
+	return updateTranslator(context.WithValue(ctx, ctxKeyBaseTranslator, t))
 }
 
 func CtxBaseTranslator(ctx context.Context) Translator {

--- a/context_propagator.go
+++ b/context_propagator.go
@@ -93,14 +93,24 @@ func (p *defaultContextPropagator) Inject(c context.Context) (map[string][]byte,
 
 func (p *defaultContextPropagator) Extract(c context.Context, m map[string][]byte) (context.Context, error) {
 	for _, k := range propagatingContextKeys {
+		// The user key is optional: Inject only writes it when a user is
+		// present, so a missing user just yields a nil user below instead
+		// of failing extraction.
+		if k == ctxKeyUser {
+			continue
+		}
 		if _, ok := m[string(k)]; !ok {
 			return nil, tracer.Trace(fmt.Errorf("key %s not found in map", k))
 		}
 	}
 
-	user, err := p.up.FromBytes(m[string(ctxKeyUser)])
-	if err != nil { // Another option would be ignoring the nil user and continue...
-		return nil, tracer.Trace(err)
+	var user User
+	if ub := m[string(ctxKeyUser)]; len(ub) > 0 {
+		u, err := p.up.FromBytes(ub)
+		if err != nil {
+			return nil, tracer.Trace(err)
+		}
+		user = u
 	}
 
 	return NewContext(c, ContextParams{

--- a/context_propagator_test.go
+++ b/context_propagator_test.go
@@ -36,6 +36,22 @@ func TestDefaultContextPropagator_Extract(t *testing.T) {
 	assert.Equal(t, result, m)
 }
 
+func TestDefaultContextPropagator_ExtractWithoutUser(t *testing.T) {
+	p := NewContextPropagator(hlog.GlobalLogger(), &emptyTranslator{})
+
+	// Inject omits the user key when there is no user, so Extract must not
+	// require it.
+	payload := map[string][]byte{
+		string(ctxKeyCorrelationId): []byte("cid"),
+		string(ctxKeyLocale):        []byte("en"),
+	}
+
+	ctx, err := p.Extract(context.Background(), payload)
+	assert.Nil(t, err)
+	assert.Nil(t, CtxUser(ctx))
+	assert.Equal(t, "cid", CtxCorrelationId(ctx))
+}
+
 func TestDefaultContextPropagator_Inject(t *testing.T) {
 	_, params := newTestContext()
 	translator := &emptyTranslator{}

--- a/context_test.go
+++ b/context_test.go
@@ -40,6 +40,14 @@ func TestNewContext(t *testing.T) {
 	assertContextWithParams(ctx, t, params)
 }
 
+func TestWithBaseTranslator(t *testing.T) {
+	tr := &emptyTranslator{}
+	ctx := WithBaseTranslator(context.Background(), tr)
+	// The base translator must be retrievable (it used to be stored under
+	// the wrong key, so CtxBaseTranslator always returned nil).
+	assert.Equal(t, tr, CtxBaseTranslator(ctx))
+}
+
 func TestWithUser(t *testing.T) {
 	ctx, params := newTestContext()
 	assert.Equal(t, CtxUser(ctx), params.User)

--- a/user.go
+++ b/user.go
@@ -256,6 +256,20 @@ func validateUserMetaData(meta map[string]any) error {
 		return tracer.Trace(errors.New("invalid type for roles field in user's meta data"))
 	}
 
+	// Validate string fields so the accessors (which type-assert to string)
+	// can't panic on a user built from arbitrary/propagated meta.
+	for _, k := range []string{
+		UserMetaKeyIdentifier,
+		UserMetaKeyEmail,
+		UserMetaKeyPhone,
+		UserMetaKeyName,
+		UserMetaKeyUsername,
+	} {
+		if _, ok := meta[k].(string); !ok {
+			return tracer.Trace(fmt.Errorf("invalid type for %s field in user's meta data, expected string", k))
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Three correctness bugs in the root `hexa` package:

- **Base translator stored under the wrong context key.** `WithBaseTranslator` wrote to `ctxKeyTranslator` (the *final* translator slot) instead of `ctxKeyBaseTranslator`, so `CtxBaseTranslator` always returned `nil` and `updateTranslator` could never re-localize when the locale changed. Now uses the base key, mirroring `WithBaseLogger`.
- **Context propagation failed without a user.** `Inject` only writes the user key when a user is present, but `Extract` required *every* propagating key (including the user) and errored otherwise — so a guest/userless context could be injected but never extracted. `Extract` now treats the user as optional and yields a `nil` user when absent.
- **User accessors could panic.** `validateUserMetaData` only checked presence of the string keys, while `Identifier()/Email()/Phone()/Name()/Username()` blindly type-assert to `string`. A user built from arbitrary or propagated meta with a non-string value panicked at call time; the types are now validated up front.

Each fix is its own commit, with regression tests for the first two.

## Test plan
- [x] `go build .`
- [x] `go test .` (incl. new `TestWithBaseTranslator`, `TestDefaultContextPropagator_ExtractWithoutUser`; existing context/user/propagator tests still pass)
- [x] `gofmt -l` clean

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_