### PR TITLE
fix(hexa): implement Unwrap on defaultError for errors.Is/As

### DIFF
--- a/error.go
+++ b/error.go
@@ -90,6 +90,12 @@ func (e defaultError) InternalError() error {
 	return e.error
 }
 
+// Unwrap exposes the internal error so the standard errors.Is and
+// errors.As can traverse the wrapped error chain.
+func (e defaultError) Unwrap() error {
+	return e.error
+}
+
 func (e defaultError) Is(err error) bool {
 	ee := AsHexaErr(err)
 	return ee != nil && e.ID() == ee.ID()

--- a/error_test.go
+++ b/error_test.go
@@ -24,3 +24,14 @@ func TestAsHexaErr(t *testing.T) {
 	hexaErr = AsHexaErr(tracer.Trace(err))
 	assert.NotNil(t, hexaErr)
 }
+
+func TestDefaultError_Unwrap(t *testing.T) {
+	sentinel := errors.New("sentinel")
+	err := NewError(http.StatusBadRequest, "lib.x").SetError(sentinel)
+
+	// errors.Is must reach the wrapped internal error through Unwrap.
+	assert.True(t, errors.Is(err, sentinel))
+
+	// A non-matching target stays false.
+	assert.False(t, errors.Is(err, errors.New("other")))
+}


### PR DESCRIPTION
## Summary

`defaultError` holds an internal/cause error (`SetError`/`InternalError`) but never exposed it via `Unwrap`, so the standard `errors.Is`/`errors.As` could not traverse the wrapped chain — matching was limited to the custom ID-based `Is`. (`AsHexaErr`'s own comment even discusses `errors.Unwrap`, but the method was missing.)

Adds `func (e defaultError) Unwrap() error { return e.error }`, so `errors.Is(hexaErr, cause)` and `errors.As` now reach the wrapped error. Purely additive — existing `Is`/`AsHexaErr` behavior is unchanged.

## Test plan
- [x] `go build .`
- [x] `go test .` (incl. new `TestDefaultError_Unwrap`; existing `TestAsHexaErr` still passes)
- [x] `gofmt -l` clean

## Compatibility
No signature changes. Behavior change: `errors.Is/As` against a hexa error now also matches its internal cause (previously it didn't). This is a bug fix; code relying on the old non-traversal would be relying on the missing behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_