### PR TITLE
fix(hurl): redact sensitive headers in request/response logs

### DIFF
--- a/hurl/client.go
+++ b/hurl/client.go
@@ -122,9 +122,13 @@ func (c *Client) Do(req *http.Request, options ...RequestOption) (*http.Response
 	}
 
 	if c.logMode&LogModeRequestHeaders != 0 {
+		// Redact sensitive headers for the dump only, then restore the real
+		// ones before sending so credentials aren't leaked to logs.
+		origHeader := req.Header
+		req.Header = redactHeaders(origHeader)
 		dumped, err := httputil.DumpRequestOut(req, c.logMode&LogModeRequestBody != 0)
-		if err !=
-			nil {
+		req.Header = origHeader
+		if err != nil {
 			return nil, tracer.Trace(err)
 		}
 
@@ -136,7 +140,10 @@ func (c *Client) Do(req *http.Request, options ...RequestOption) (*http.Response
 	}
 
 	if c.logMode&LogModeResponseHeaders != 0 {
+		origHeader := resp.Header
+		resp.Header = redactHeaders(origHeader)
 		dumped, err := httputil.DumpResponse(resp, c.logMode&LogModeResponseBody != 0)
+		resp.Header = origHeader
 		if err != nil {
 			return nil, tracer.Trace(err)
 		}
@@ -145,4 +152,30 @@ func (c *Client) Do(req *http.Request, options ...RequestOption) (*http.Response
 	}
 
 	return resp, nil
+}
+
+// sensitiveHeaders are request/response headers whose values are masked
+// before a message is dumped to logs, so credentials and session data don't
+// leak when LogMode*Headers is enabled.
+var sensitiveHeaders = []string{
+	"Authorization",
+	"Proxy-Authorization",
+	"Cookie",
+	"Set-Cookie",
+}
+
+// redactHeaders returns a copy of h with the values of sensitiveHeaders
+// replaced by "REDACTED". The input header is left unmodified. It is nil-safe.
+func redactHeaders(h http.Header) http.Header {
+	if h == nil {
+		return nil
+	}
+
+	clone := h.Clone()
+	for _, name := range sensitiveHeaders {
+		if len(clone.Values(name)) != 0 {
+			clone.Set(name, "REDACTED")
+		}
+	}
+	return clone
 }

--- a/hurl/util_test.go
+++ b/hurl/util_test.go
@@ -1,10 +1,31 @@
 package hurl
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRedactHeaders(t *testing.T) {
+	h := http.Header{}
+	h.Set("Authorization", "Bearer secret-token")
+	h.Add("Cookie", "session=abc")
+	h.Set("Content-Type", "application/json")
+
+	red := redactHeaders(h)
+
+	// Sensitive headers are masked in the copy.
+	assert.Equal(t, "REDACTED", red.Get("Authorization"))
+	assert.Equal(t, "REDACTED", red.Get("Cookie"))
+	// Non-sensitive headers are preserved.
+	assert.Equal(t, "application/json", red.Get("Content-Type"))
+	// The original header is untouched.
+	assert.Equal(t, "Bearer secret-token", h.Get("Authorization"))
+
+	// nil-safe.
+	assert.Nil(t, redactHeaders(nil))
+}
 
 func Test_isValidUrl(t *testing.T) {
 	urls := []struct {


### PR DESCRIPTION
## Summary

With `LogModeRequestHeaders`/`LogModeResponseHeaders` (and thus `LogModeAll`) enabled, `httputil.DumpRequestOut`/`DumpResponse` wrote the full `Authorization`, `Cookie`, and `Set-Cookie` headers into the logs — leaking bearer tokens, basic-auth credentials, and session data.

This masks those headers (value → `REDACTED`) on a **copy** used only for the dump. The real `req`/`resp` headers are restored immediately, so the request still sends the real credentials and body handling is unchanged. Redacted set: `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`.

## Test plan
- [x] `go build ./hurl/...`, `go vet ./hurl/...`
- [x] `go test ./hurl/...` (new `TestRedactHeaders` covers masking, preservation of other headers, original-untouched, nil-safety)
- [x] `gofmt -l hurl/` clean

## Compatibility
No API changes. Behavior change: debug log output now shows `REDACTED` for those headers instead of the real values. If anyone needs the full set redacted differently, `sensitiveHeaders` can be made configurable in a follow-up.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_