### PR TITLE
docs: add CHANGELOG and correct README Go version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,86 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+This project is pre-1.0 and does not yet follow semantic versioning.
+
+## [Unreleased]
+
+### Security
+
+- **hurl:** Sensitive headers (`Authorization`, `Proxy-Authorization`, `Cookie`,
+  `Set-Cookie`) are now redacted as `REDACTED` when requests/responses are dumped
+  to logs via the `LogMode*Headers` flags, so credentials and session data no
+  longer leak into logs. (#13)
+
+### Fixed
+
+- **hurl:** Repaired a broken build in `error.go` — `io` was used without being
+  imported, the error literal referenced an undefined `HttpErr` (the type is
+  `HTTPErr`), and the function was named `responseErr` while its only caller used
+  the exported `ResponseErr`. The error path now also closes the response body it
+  reads. (#6)
+- **hurl:** `NewClient` created with an empty base no longer panics on a relative
+  request path; it returns a clear error instead. (#6)
+- **sr:** `multiSearchRegistry.Descriptors()` no longer drops the first searched
+  registry (an off-by-one in the reverse loop). (#7)
+- **sr:** `RegisterByDescriptor` no longer overwrites an explicitly provided
+  `Descriptor.Health` with the instance's own `Health`. (#7)
+- **hdlm/redislock:** `Unlock` now actually releases the lock (it was a no-op).
+  The lock handle is retained so it can be released or refreshed, repeated
+  `(Try)Lock` calls refresh the lease instead of reporting the lock as taken, and
+  a transient `Release` failure preserves the handle so callers can retry. (#8)
+- **hdlm/redislock:** `NewDlm` now initializes the embedded `Health`, preventing a
+  nil-interface panic when the DLM is registered as a health check. (#8)
+- **hlog:** `SetGlobalLogger` now binds the global `Message` function to the
+  driver's `Message` (it was bound to `Info`). (#9)
+- **hlog:** `FieldToKeyVal` decodes log fields to their real Go values instead of
+  raw integer bits, so bool/float/duration/time fields are no longer reported as
+  numbers. (#9)
+- **lg:** `UseEmbeddedFieldsInPackage` returns the repackaged embedded fields
+  instead of the original slice. (#10)
+- **hexa:** `WithBaseTranslator` stores the base translator under the correct
+  context key, so `CtxBaseTranslator` works and the translator re-localizes when
+  the locale changes. (#11)
+- **hexa:** The default context propagator can now extract a context that carries
+  no user (it previously required the user key and failed otherwise). (#11)
+- **hexa:** User accessors can no longer panic on non-string meta values —
+  `validateUserMetaData` validates the string fields up front. (#11)
+- **hexa:** `defaultError` implements `Unwrap`, so `errors.Is`/`errors.As`
+  traverse to the wrapped internal error. (#12)
+
+### Changed
+
+- **hexa:** After `WithBaseTranslator`, `CtxTranslator` returns the *localized*
+  translator and re-localizes on locale change (previously it returned the
+  unlocalized base translator). (#11)
+
+### ⚠️ Upgrade notes (observable behavior changes)
+
+- **Stricter user construction:** `NewUserFromMeta` / `MustNewUserFromMeta` /
+  `User.SetMeta` now reject meta whose `id`/`email`/`phone`/`name`/`username`
+  values are not strings, returning an error at construction (or panicking, for
+  the `Must` variant) where previously construction succeeded and only the
+  accessor panicked. (#11)
+- **`hlog.FieldToKeyVal` output types:** custom log drivers that consume this
+  exported function now receive properly-typed values (e.g. `bool`,
+  `time.Duration`) instead of `int64`. (#9)
+- **Sentry now emits messages:** with the Sentry driver installed, `hlog.Message`
+  now triggers `CaptureMessage`; expect message-level events that were previously
+  dropped. (#9)
+- **`errors.Is`/`errors.As`** against a hexa error now also match its internal
+  cause. (#12)
+
+### Compatibility
+
+No exported symbols were removed, renamed, or had their signatures changed.
+`hurl.ResponseErr` is newly exported (additive); the `hurl` package did not
+compile before #6.
+
+## [0.1.0]
+
+Initial tagged release.
+
+[Unreleased]: https://github.com/Kamva/hexa/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Kamva/hexa/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ __Note : Hexa is in progress, it does not have stable version until now, so use 
 
 #### Requirements:
 
-go : minimum version `1.13`
+go : minimum version `1.18`
 
 #### Install
 


### PR DESCRIPTION
## Summary

Documentation only — no code changes.

- **`CHANGELOG.md`** (new): a [Keep a Changelog](https://keepachangelog.com/)-style log with everything under `[Unreleased]`, documenting #6–#13:
  - **Security:** hurl header redaction (#13)
  - **Fixed:** the eleven bug fixes across `hurl`, `sr`, `hdlm/redislock`, `hlog`, `lg`, and the root `hexa` package
  - **Changed** + a dedicated **⚠️ Upgrade notes** section calling out the observable behavior changes (stricter user-meta validation, `FieldToKeyVal` output types, Sentry now emitting messages, `errors.Is/As` traversal)
  - **Compatibility** note: no exported symbols removed/renamed/re-signed
- **`README.md`:** corrected the stated minimum Go version from `1.13` → `1.18` to match `go.mod` and the use of the `any` builtin.

The changelog references #12 and #13, which are still open at the time of writing — they're grouped under `[Unreleased]` and will land alongside this.

## Notes
- Left a `[0.1.0]` anchor (the only existing tag) without inventing its contents.
- Did **not** touch the `version.go` `Version = "1.1.0"` constant (it predates the only tag `v0.1.0`); happy to reconcile that separately if you want.
- Godoc touch-ups (e.g. noting redaction on the `LogMode*` constants) were left out to keep this docs-only; I can add them in a small follow-up.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_