### PR TITLE
test(hexa): cover health, reply, Secret, propagation helpers (44% → ~59%)

### DIFF
--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,78 @@
+package hexa
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kamva/hexa/hlog"
+	"github.com/stretchr/testify/assert"
+)
+
+func aliveHealth(id string) Health {
+	return NewPingHealth(hlog.NewPrinterDriver(hlog.ErrorLevel), id, func(context.Context) error { return nil }, nil)
+}
+
+func deadHealth(id string) Health {
+	return NewPingHealth(hlog.NewPrinterDriver(hlog.ErrorLevel), id, func(context.Context) error { return errors.New("down") }, nil)
+}
+
+func TestPingHealth(t *testing.T) {
+	ctx := context.Background()
+
+	ok := NewPingHealth(hlog.NewPrinterDriver(hlog.ErrorLevel), "id1",
+		func(context.Context) error { return nil }, map[string]string{"k": "v"})
+	assert.Equal(t, "id1", ok.HealthIdentifier())
+	assert.Equal(t, StatusAlive, ok.LivenessStatus(ctx))
+	assert.Equal(t, StatusReady, ok.ReadinessStatus(ctx))
+	hs := ok.HealthStatus(ctx)
+	assert.Equal(t, StatusAlive, hs.Alive)
+	assert.Equal(t, StatusReady, hs.Ready)
+	assert.Equal(t, "v", hs.Tags["k"])
+
+	bad := deadHealth("id2")
+	assert.Equal(t, StatusDead, bad.LivenessStatus(ctx))
+	assert.Equal(t, StatusUnReady, bad.ReadinessStatus(ctx))
+	assert.Equal(t, StatusUnReady, bad.HealthStatus(ctx).Ready)
+}
+
+func TestHealthReporter_AllHealthy(t *testing.T) {
+	ctx := context.Background()
+	r := NewHealthReporter().AddToChecks(aliveHealth("a"))
+
+	assert.Equal(t, StatusAlive, r.LivenessStatus(ctx))
+	assert.Equal(t, StatusReady, r.ReadinessStatus(ctx))
+
+	report := r.HealthReport(ctx)
+	assert.Equal(t, StatusAlive, report.Alive)
+	assert.Equal(t, StatusReady, report.Ready)
+	assert.Len(t, report.Statuses, 1)
+}
+
+func TestHealthReporter_Unhealthy(t *testing.T) {
+	ctx := context.Background()
+	r := NewHealthReporter().
+		AddLivenessChecks(deadHealth("d")).
+		AddReadinessChecks(deadHealth("d")).
+		AddStatusChecks(deadHealth("d"))
+
+	assert.Equal(t, StatusDead, r.LivenessStatus(ctx))
+	assert.Equal(t, StatusUnReady, r.ReadinessStatus(ctx))
+	assert.Equal(t, StatusDead, r.HealthReport(ctx).Alive)
+}
+
+func TestAliveAndReadyStatus(t *testing.T) {
+	allOK := []HealthStatus{
+		{Alive: StatusAlive, Ready: StatusReady},
+		{Alive: StatusAlive, Ready: StatusReady},
+	}
+	assert.Equal(t, StatusAlive, AliveStatus(allOK...))
+	assert.Equal(t, StatusReady, ReadyStatus(allOK...))
+
+	mixed := []HealthStatus{
+		{Alive: StatusAlive, Ready: StatusReady},
+		{Alive: StatusDead, Ready: StatusUnReady},
+	}
+	assert.Equal(t, StatusDead, AliveStatus(mixed...))
+	assert.Equal(t, StatusUnReady, ReadyStatus(mixed...))
+}

--- a/reply_test.go
+++ b/reply_test.go
@@ -1,0 +1,22 @@
+package hexa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReply(t *testing.T) {
+	r := NewReply(200, "lib.ok")
+	assert.Equal(t, 200, r.HTTPStatus())
+	assert.Equal(t, "lib.ok", r.ID())
+	assert.Nil(t, r.Data())
+
+	// Setters return a modified copy and leave the original untouched.
+	r2 := r.SetHTTPStatus(201).SetData(Map{"a": 1})
+	assert.Equal(t, 201, r2.HTTPStatus())
+	assert.Equal(t, Map{"a": 1}, r2.Data())
+
+	assert.Equal(t, 200, r.HTTPStatus())
+	assert.Nil(t, r.Data())
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,33 @@
+package hexa
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecret_Masks(t *testing.T) {
+	s := Secret("super-secret")
+
+	assert.Equal(t, "****", s.String())
+	assert.Equal(t, "****", fmt.Sprintf("%s", s))
+
+	b, err := s.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, `"****"`, string(b))
+}
+
+func TestExtendBytesMap(t *testing.T) {
+	dest := map[string][]byte{"a": []byte("1")}
+	src := map[string][]byte{"a": []byte("2"), "b": []byte("3")}
+
+	// Without overwrite, existing keys are kept.
+	extendBytesMap(dest, src, false)
+	assert.Equal(t, "1", string(dest["a"]))
+	assert.Equal(t, "3", string(dest["b"]))
+
+	// With overwrite, existing keys are replaced.
+	extendBytesMap(dest, map[string][]byte{"a": []byte("9")}, true)
+	assert.Equal(t, "9", string(dest["a"]))
+}

--- a/user_propagator_test.go
+++ b/user_propagator_test.go
@@ -1,0 +1,44 @@
+package hexa
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserPropagator_RoundTrip(t *testing.T) {
+	p := NewUserPropagator()
+	u := NewUser(UserParams{
+		Id:       "1",
+		Type:     UserTypeRegular,
+		Email:    "a@b.com",
+		Phone:    "+1",
+		Name:     "n",
+		UserName: "un",
+		IsActive: true,
+		Roles:    []string{"r1", "r2"},
+	})
+
+	b, err := p.ToBytes(u)
+	require.NoError(t, err)
+
+	got, err := p.FromBytes(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1", got.Identifier())
+	assert.Equal(t, UserTypeRegular, got.Type())
+	assert.Equal(t, "a@b.com", got.Email())
+	assert.True(t, got.IsActive())
+	assert.Equal(t, []string{"r1", "r2"}, got.Roles())
+}
+
+func TestUserPropagator_FromInvalidBytes(t *testing.T) {
+	_, err := NewUserPropagator().FromBytes([]byte("not json"))
+	assert.Error(t, err)
+}
+
+func TestSessionFromContext_Absent(t *testing.T) {
+	assert.Nil(t, SessionFromContext(context.Background()))
+}


### PR DESCRIPTION
## Summary

Fills gaps in the root `hexa` package (44.3% → **~59%**):
- `health.go` / `health_impl.go` — ping health (alive/dead → liveness, readiness, status+tags), the health reporter aggregation across liveness/readiness/status checks, and `AliveStatus`/`ReadyStatus`
- `reply.go` — `Reply` getters/setters and value semantics
- `types.go` — `Secret` masking via `String` and `MarshalJSON`
- `util.go` — `extendBytesMap` overwrite/keep behavior
- `user_propagator.go` — `ToBytes`/`FromBytes` round-trip and invalid-bytes error
- `session.go` — `SessionFromContext` absent case

## Test plan
- [x] `go test . -race -cover` → all pass, 44.3% → 59.1%
- [x] `gofmt -l` clean, `go vet .`

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_