### PR TITLE
fix: registry mutex, LevelFromString error, hurl status threshold

### DIFF
--- a/hlog/level.go
+++ b/hlog/level.go
@@ -37,19 +37,20 @@ func (l Level) CanLog(target Level) bool {
 	return l <= target
 }
 
-// LevelFromString converts string to log level.
-func LevelFromString(l string) Level {
+// LevelFromString converts a string to a log level, returning an error for an
+// unknown value instead of panicking.
+func LevelFromString(l string) (Level, error) {
 	switch l {
 	case DebugLevel.String():
-		return DebugLevel
+		return DebugLevel, nil
 	case InfoLevel.String():
-		return InfoLevel
+		return InfoLevel, nil
 	case WarnLevel.String():
-		return WarnLevel
+		return WarnLevel, nil
 	case ErrorLevel.String():
-		return ErrorLevel
+		return ErrorLevel, nil
 	default:
-		panic("invalid log level")
+		return 0, fmt.Errorf("invalid log level: %q", l)
 	}
 }
 

--- a/hlog/log_test.go
+++ b/hlog/log_test.go
@@ -40,9 +40,16 @@ func TestLevel_CanLog(t *testing.T) {
 }
 
 func TestLevelFromString(t *testing.T) {
-	assert.Equal(t, DebugLevel, LevelFromString("debug"))
-	assert.Equal(t, ErrorLevel, LevelFromString("error"))
-	assert.Panics(t, func() { LevelFromString("nope") })
+	lvl, err := LevelFromString("debug")
+	require.NoError(t, err)
+	assert.Equal(t, DebugLevel, lvl)
+
+	lvl, err = LevelFromString("error")
+	require.NoError(t, err)
+	assert.Equal(t, ErrorLevel, lvl)
+
+	_, err = LevelFromString("nope")
+	assert.Error(t, err)
 }
 
 func TestZapLevel(t *testing.T) {

--- a/hurl/error.go
+++ b/hurl/error.go
@@ -17,9 +17,10 @@ func (err HTTPErr) Error() string {
 	return fmt.Sprintf("HTTP code: %d, msg: %s, status: %s, body: %s", err.Code, http.StatusText(err.Code), err.Status, err.Body)
 }
 
-// ResponseErr returns http error if the response is not successful.
+// ResponseErr returns an http error if the response is a client or server
+// error (status >= 400). 2xx and 3xx responses are not treated as errors.
 func ResponseErr(r *http.Response) error {
-	if r.StatusCode <= 300 {
+	if r.StatusCode < 400 {
 		return nil
 	}
 

--- a/hurl/error_test.go
+++ b/hurl/error_test.go
@@ -1,0 +1,40 @@
+package hurl
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func resp(code int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: code,
+		Status:     http.StatusText(code),
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestResponseErr_StatusBoundary(t *testing.T) {
+	// 2xx and 3xx are not errors; 4xx/5xx are.
+	assert.NoError(t, ResponseErr(resp(http.StatusOK, "")))
+	assert.NoError(t, ResponseErr(resp(http.StatusNoContent, "")))
+	assert.NoError(t, ResponseErr(resp(http.StatusFound, "")))           // 302 redirect
+	assert.NoError(t, ResponseErr(resp(http.StatusMultipleChoices, ""))) // 300
+
+	assert.Error(t, ResponseErr(resp(http.StatusBadRequest, "bad")))           // 400
+	assert.Error(t, ResponseErr(resp(http.StatusInternalServerError, "boom"))) // 500
+}
+
+func TestResponseErr_CarriesCodeAndBody(t *testing.T) {
+	err := ResponseErr(resp(http.StatusNotFound, "missing"))
+	require.Error(t, err)
+
+	httpErr, ok := err.(HTTPErr)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusNotFound, httpErr.Code)
+	assert.Equal(t, "missing", httpErr.Body)
+}

--- a/sr/registry.go
+++ b/sr/registry.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"sync"
 	"sync/atomic"
 
 	"github.com/kamva/hexa"
@@ -15,7 +16,8 @@ import (
 )
 
 type serviceRegistry struct {
-	l []*hexa.Descriptor
+	mu sync.RWMutex
+	l  []*hexa.Descriptor
 
 	booted     uint32 // is 1 if you boot services.
 	done       uint32 // is 1 if you shutdown services.
@@ -44,7 +46,10 @@ func (r *serviceRegistry) RegisterByInstance(instance hexa.Service) {
 }
 
 func (r *serviceRegistry) RegisterByDescriptor(d *hexa.Descriptor) {
-	if r.Service(d.Name) != nil {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.descriptor(d.Name) != nil {
 		hlog.Warn("you are overwriting service in service registry", hlog.String("name", d.Name))
 	}
 
@@ -132,10 +137,24 @@ func (r *serviceRegistry) ShutdownCh() (shutdownCh chan struct{}) {
 }
 
 func (r *serviceRegistry) Descriptors() []*hexa.Descriptor {
-	return r.l
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// Return a copy so callers can iterate without racing a concurrent Register.
+	out := make([]*hexa.Descriptor, len(r.l))
+	copy(out, r.l)
+	return out
 }
 
 func (r *serviceRegistry) Descriptor(name string) *hexa.Descriptor {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.descriptor(name)
+}
+
+// descriptor looks up a descriptor by name without locking; callers must hold
+// at least the read lock.
+func (r *serviceRegistry) descriptor(name string) *hexa.Descriptor {
 	// TODO: Use a map if needed (to improve performance)
 	for _, d := range r.l {
 		if d.Name == name {
@@ -146,7 +165,9 @@ func (r *serviceRegistry) Descriptor(name string) *hexa.Descriptor {
 }
 
 func (r *serviceRegistry) Service(name string) hexa.Service {
-	if d := r.Descriptor(name); d != nil {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if d := r.descriptor(name); d != nil {
 		return d.Instance
 	}
 	return nil


### PR DESCRIPTION
## Summary

The "small correctness fixes" workstream from the v1 plan (Phase 2 deferred items). Three independent fixes, one commit each:

- **`sr`**: the registry's descriptor slice was mutated by `Register*` while read by `Boot`/`Service`/`Descriptor(s)`/shutdown with only `booted`/`done` as atomics — a data race. Added a `sync.RWMutex`, `Descriptors()` now returns a copy, and lookups use a non-locking internal helper to avoid reentrant read-lock deadlocks.
- **`hlog`** ⚠️ **breaking**: `LevelFromString` panicked on an unknown string. It now returns `(Level, error)`. Pre-1.0, and it has no internal callers besides its test (updated).
- **`hurl`**: `ResponseErr` used `<= 300` (flagged 301–399 as errors, treated 300 as success). Now uses the conventional boundary — `>= 400` is an error; 2xx/3xx are not. New `error_test.go` locks in the boundary.

## Test plan
- [x] `go test ./sr/... ./hlog/... ./hurl/... -race` → all pass
- [x] `gofmt -l` clean, `go vet`
- [x] `golangci-lint` (v1.64.8): no findings in the changed files (the 7 it still reports are PR #27's, resolved when that merges)

## Notes
- Branched off `master` (pre-#27); touches different files than #27, so no conflicts.
- The `LevelFromString` signature change should be called out in `CHANGELOG.md` under the upcoming release's "Changed".

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_