### PR TITLE
chore: go mod tidy + package godoc (no breaking changes)

### DIFF
--- a/db/mgmadapter/doc.go
+++ b/db/mgmadapter/doc.go
@@ -1,0 +1,4 @@
+// Package mgmadapter adapts the mgm MongoDB ODM to hexa, providing entity
+// base structs, a hexa.ID implementation over primitive.ObjectID, touchable
+// (version and timestamp) models, index helpers and command monitoring.
+package mgmadapter

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,10 @@
+// Package hexa is a microservice SDK for the Kamva ecosystem.
+//
+// It provides the core, transport-agnostic building blocks for building
+// microservices: a propagatable request Context (carrying the user,
+// correlation id, locale, logger, translator and a concurrency-safe store),
+// a structured Error/Reply model, users and user propagation, health
+// reporting, a service registry with ordered boot/shutdown, distributed
+// locks, and supporting utilities. Most capabilities are defined as
+// interfaces with swappable driver implementations in sub-packages.
+package hexa

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/kamva/hexa
 go 1.18
 
 require (
+	github.com/bsm/redislock v0.9.4
 	github.com/getsentry/sentry-go v0.6.1
 	github.com/kamva/gutil v0.0.0-20210827084201-35b6a3421580
 	github.com/kamva/mgm/v3 v3.4.0
@@ -10,6 +11,7 @@ require (
 	github.com/labstack/gommon v0.3.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/nicksnyder/go-i18n/v2 v2.0.3
+	github.com/redis/go-redis/v9 v9.7.0
 	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.7.0
 	go.opentelemetry.io/otel v1.2.0
@@ -23,7 +25,6 @@ require (
 )
 
 require (
-	github.com/bsm/redislock v0.9.4 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/redis/go-redis/v9 v9.7.0 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.0.2 // indirect
 	github.com/xdg-go/stringprep v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqR
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/bsm/redislock v0.9.4 h1:X/Wse1DPpiQgHbVYRE9zv6m070UcKoOGekgvpNhiSvw=
 github.com/bsm/redislock v0.9.4/go.mod h1:Epf7AJLiSFwLCiZcfi6pWFO/8eAYrYpQXFxEDPoDeAk=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=

--- a/hdlm/mongolock/doc.go
+++ b/hdlm/mongolock/doc.go
@@ -1,0 +1,3 @@
+// Package mongolock implements hexa's distributed lock manager (hexa.DLM) on
+// top of MongoDB.
+package mongolock

--- a/hdlm/redislock/doc.go
+++ b/hdlm/redislock/doc.go
@@ -1,0 +1,3 @@
+// Package redislock implements hexa's distributed lock manager (hexa.DLM) on
+// top of Redis.
+package redislock

--- a/hexamask/doc.go
+++ b/hexamask/doc.go
@@ -1,0 +1,4 @@
+// Package hexamask provides field masks for detecting which fields of a
+// struct or map were supplied by a caller (for example, the fields present in
+// a PATCH request) so partial updates can be applied safely.
+package hexamask

--- a/hexatranslator/doc.go
+++ b/hexatranslator/doc.go
@@ -1,0 +1,4 @@
+// Package hexatranslator provides hexa.Translator implementations, including
+// an i18n driver backed by go-i18n, plus empty and key drivers for tests, and
+// a process-global translator.
+package hexatranslator

--- a/hlog/doc.go
+++ b/hlog/doc.go
@@ -1,0 +1,4 @@
+// Package hlog is hexa's structured logging facade. It defines the Logger
+// interface, log levels and fields, and a process-global logger; concrete
+// drivers (zap, sentry, ...) live in the logdriver sub-package.
+package hlog

--- a/hlog/logdriver/doc.go
+++ b/hlog/logdriver/doc.go
@@ -1,0 +1,3 @@
+// Package logdriver contains concrete hlog.Logger drivers, including zap and
+// sentry implementations.
+package logdriver

--- a/htel/doc.go
+++ b/htel/doc.go
@@ -1,0 +1,4 @@
+// Package htel provides OpenTelemetry helpers for hexa: wrappers that let the
+// tracer/meter providers participate in service shutdown, and a propagator
+// that bridges hexa's context propagation with OpenTelemetry.
+package htel

--- a/hurl/doc.go
+++ b/hurl/doc.go
@@ -1,0 +1,4 @@
+// Package hurl is an improved net/http client: it resolves request paths
+// against a base URL, applies request options (auth headers, query params,
+// ...), and can log requests and responses with sensitive headers redacted.
+package hurl

--- a/lg/doc.go
+++ b/lg/doc.go
@@ -1,0 +1,5 @@
+// Package lg is a layer/code generator. It parses Go packages into a metadata
+// model (interfaces, structs, methods, fields, annotations), resolves embedded
+// types, and renders templates — used to generate hexagonal layers from
+// interface definitions.
+package lg

--- a/probe/doc.go
+++ b/probe/doc.go
@@ -1,0 +1,4 @@
+// Package probe provides a small HTTP server that exposes liveness, readiness
+// and status (health) endpoints plus optional pprof handlers, suitable for
+// Kubernetes probes.
+package probe


### PR DESCRIPTION
## Summary

Non-breaking dependency hygiene + the godoc half of the docs workstream. **No API or behavior changes, no runtime dependency version bumps, `go` directive stays at 1.18.**

- **`go mod tidy`** — moves `bsm/redislock` and `redis/go-redis/v9` from `// indirect` to direct requires (they're imported directly by `hdlm/redislock`) and completes `go.sum`. No version changes → not consumer-facing.
- **Package godoc** — added a `doc.go` package comment to every library package that lacked one (root `hexa`, `db/mgmadapter`, `hdlm/mongolock`, `hdlm/redislock`, `hexamask`, `hexatranslator`, `hlog`, `hlog/logdriver`, `htel`, `hurl`, `lg`, `probe`), so godoc / pkg.go.dev show a useful overview.

## Test plan
- [x] `gofmt -l .` clean, `go vet ./...`, `go build ./...`
- [x] `golangci-lint run ./...` (v1.64.8) → **EXIT=0** (passes the new hard gate)
- [x] `go test ./...` → all pass

## ⚠️ On the rest of "modernize dependencies" (needs your call)
You asked to bump otel/mongo-driver/zap/go-i18n, but flagged **no breaking changes**. Those bumps **are** consumer-facing because hexa re-exports the libraries' types in its public API:
- **otel (the blocker):** `htel` exposes `metric.MeterProvider`, and otel's `metric` package had a **v0.x → v1.x redesign**. You can't bump otel core without pulling the new, incompatible metric API → anyone implementing/passing those types breaks. This is the "crucial but breaking" one — I'd defer it to a coordinated **v2** (`/v2` module path).
- **mongo-driver / zap / go-i18n:** within-major bumps are backward-compatible in semver terms, but they still transitively upgrade consumers' versions of those libs. Lower risk, but still consumer-facing.

So I did **not** bump any runtime dependency here. Tell me how you'd like to proceed (defer otel to v2; do the within-major mongo/zap/i18n bumps as an accepted transitive upgrade; or hold).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J46cm6MaKsVpw1YSXGg8eq)_